### PR TITLE
Feature/sync method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ CLI for publishing a new change to your hyperdrive and syncing it with remote pe
 - This will:
 	- Wait to connect to a peer for your drive
 	- Make sure the metadata has been synced with a peer
-	- Sync data from the `./public` folder on your filesystem to the `/website` folder in the hyperdrive	
-	- Wait for 5 seconds to sync with the peer (configurable with `--sync-time`)
-	- Exit 
+	- Sync data from the `./public` folder on your filesystem to the `/website` folder in the hyperdrive
+	- Count every block that got uploaded to a remote peer, wait for all the new files to have been uploaded
+	- Exit
 
 ### Get URL
 
@@ -90,11 +90,10 @@ You'll need to use `getURL` and add it to a `dat-store` beforehand otherwise it'
 - `url` will be the `hyper://` URL of the hyperdrive that got generated for this seed
 - `verbose` controls whether there will be console output. By default it's false so that you don't have junk in your logs
 
-### `const {diff, url} = await sync({seed, syncTime = 5000, fsPath='./', drivePath='/', verbose=false})`
+### `const {diff, url} = await sync({seed, fsPath='./', drivePath='/', verbose=false})`
 
 - `seed` is the seed used to generate the Hyperdrive, ths must be provided.
 - `url` will be the `hyper://` URL of the hyperdrive that got generated for this seed
-- `syncTime` is how long the publisher will wait for a sync to propogate to your peers starting at the initial upload
 - `fsPath` is the file path (relative to the current working directory) to sync files from
 - `drivePath` is the folder inside the hyperdrive you'd like files to be synced to
 - `verbose` controls whether there will be console output. By default it's false so that you don't have junk in your logs
@@ -104,3 +103,4 @@ You'll need to use `getURL` and add it to a `dat-store` beforehand otherwise it'
 You can place [./publish.yml] in your `.github/workflows/` folder and add your seed as a secret key called `PUBLISHER_KEY` in order to publish changes on every push.
 
 Make sure you have the appropriate branch set in the config, the default is `default`.
+

--- a/bin.js
+++ b/bin.js
@@ -20,10 +20,6 @@ require('yargs')
     'sync <seed> [fsPath] [drivePath]',
     'sync a folder to your hyperdrive',
     {
-      syncTime: {
-        default: 5000,
-        describe: 'How long to wait to sync with remote peers'
-      },
       verbose: {
         alias: 'v',
         default: true,

--- a/bin.js
+++ b/bin.js
@@ -12,6 +12,11 @@ require('yargs')
         alias: 'v',
         default: true,
         describe: 'Toggles console output'
+      },
+      title: {
+        alias: 't',
+        describe: 'Title for your hyperdrive',
+        type: 'string'
       }
     },
     create

--- a/index.js
+++ b/index.js
@@ -312,11 +312,12 @@ function trackAckBitfield (core) {
 
   function onAck (peer, have) {
     if (have.ack) {
+      // TODO Account for when `have.bitfield` isn't null
       const end = have.start + have.length
       for (let i = have.start; i < end; i++) {
         ackBitfield.set(i, true)
       }
-      // Fill seems to be causing errors and I'm not sure why
+      // TODO: Fill seems to be causing errors and I'm not sure why
       // ackBitfield.fill(true, have.start, have.start + have.length)
     } else {
       // This isn't an ack event

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "hyperdrive-publisher": "bin.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "standard"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,10 @@
   "dependencies": {
     "dat-sdk": "^2.8.1",
     "diff-file-tree": "^2.5.0",
+    "lodash.debounce": "^4.0.8",
     "yargs": "^16.1.0"
+  },
+  "devDependencies": {
+    "standard": "^16.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/RangerMauve/hyperdrive-publisher#readme",
   "dependencies": {
-    "dat-sdk": "^3.0.6",
     "diff-file-tree": "^2.5.0",
     "fast-bitfield": "^1.2.2",
+    "hyper-sdk": "^3.0.7",
     "lodash.debounce": "^4.0.8",
     "yargs": "^16.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "format": "standard"
+    "lint": "standard --fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "diff-file-tree": "^2.5.0",
     "fast-bitfield": "^1.2.2",
     "hyper-sdk": "^3.0.7",
-    "lodash.debounce": "^4.0.8",
     "yargs": "^16.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "hyperdrive-publisher": "bin.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test.js",
     "lint": "standard --fix"
   },
   "repository": {
@@ -29,10 +29,11 @@
   "dependencies": {
     "diff-file-tree": "^2.5.0",
     "fast-bitfield": "^1.2.2",
-    "hyper-sdk": "^3.0.7",
+    "hyper-sdk": "^3.0.9",
     "yargs": "^16.1.0"
   },
   "devDependencies": {
-    "standard": "^16.0.3"
+    "standard": "^16.0.3",
+    "tape": "^5.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   },
   "homepage": "https://github.com/RangerMauve/hyperdrive-publisher#readme",
   "dependencies": {
-    "dat-sdk": "^2.8.1",
+    "dat-sdk": "^3.0.6",
     "diff-file-tree": "^2.5.0",
+    "fast-bitfield": "^1.2.2",
     "lodash.debounce": "^4.0.8",
     "yargs": "^16.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -1,0 +1,83 @@
+const tape = require('tape')
+const crypto = require('crypto')
+const path = require('path')
+
+const { sync, create, getURL } = require('./')
+
+const SDK = require('hyper-sdk')
+
+tape('Create an archive', async (t) => {
+  const { seed, url, drive, cleanup } = await setup()
+
+  try {
+    const title = 'Testing'
+
+    const { url: gotURL } = await create({ seed, title })
+
+    t.equal(gotURL, url, 'create generated expected URL')
+
+    const files = await drive.readdir('/')
+
+    t.deepEqual(files, ['index.json'], 'Generated index file')
+
+    const content = await drive.readFile('index.json', 'utf8')
+
+    t.ok(content, 'Able to load index.json from seeder')
+
+    const parsed = JSON.parse(content)
+
+    t.equal(parsed.title, title, 'Title got used')
+  } finally {
+    await cleanup()
+  }
+})
+
+tape('Create and sync', async (t) => {
+  const { seed, url, drive, cleanup } = await setup()
+
+  try {
+    await create({ seed })
+
+    const fsPath = path.join(__dirname, 'example')
+
+    const { diff, url: gotURL } = await sync({ seed, fsPath })
+
+    t.equal(gotURL, url, 'create generated expected URL')
+
+    const files = await drive.readdir('/')
+
+    t.deepEqual(files.sort(), ['index.html', 'index.json'], 'Uploaded expected files')
+
+    t.equal(diff.length, 2, 'Found diffs')
+  } finally {
+    await cleanup()
+  }
+})
+
+async function setup () {
+  const { Hyperdrive, close } = await SDK({ persist: false })
+  try {
+    const seed = getSeed()
+
+    const { url } = await getURL({ seed })
+
+    const drive = Hyperdrive(url, {
+      sparse: false,
+      sparseMetadata: false
+    })
+
+    return {
+      seed,
+      url,
+      drive,
+      cleanup: close
+    }
+  } catch (e) {
+    await close()
+    throw e
+  }
+}
+
+function getSeed () {
+  return crypto.randomBytes(32)
+}


### PR DESCRIPTION
⚠️ This is a WIP

This PR adds two new methods that aim to improve the data sync phase:

- `updateStats`: runs on every `upload` event. This methods creates a list of `[<{file, start,end}>]` that is used to track start and end of each drive file (based on stat response). This method is debounced.
- `checkPeersSync`:  checks if there is at least one peer that is up to date with our drive. This method uses the stats generated with `updateStats`.

This work is based on https://github.com/RangerMauve/hyperdrive-publisher/issues/8#issuecomment-752243521
